### PR TITLE
perf: pre-allocate values list in BoundStatement.bind()

### DIFF
--- a/cassandra/query.py
+++ b/cassandra/query.py
@@ -635,13 +635,24 @@ class BoundStatement(Statement):
                 (value_len, len(self.prepared_statement.routing_key_indexes)))
 
         self.raw_values = values
-        self.values = []
-        for value, col_spec in zip(values, col_meta):
+
+        # Pre-allocate the values list to avoid repeated append() calls and
+        # list resizing. For proto v4+, trailing unbound columns default to
+        # UNSET_VALUE; for proto v3, we only allocate for provided values.
+        if proto_version >= 4:
+            result = [UNSET_VALUE] * col_meta_len
+        else:
+            result = [None] * value_len
+
+        for i, (value, col_spec) in enumerate(zip(values, col_meta)):
             if value is None:
-                self.values.append(None)
+                result[i] = None
             elif value is UNSET_VALUE:
                 if proto_version >= 4:
-                    self._append_unset_value()
+                    if self.prepared_statement.is_routing_key_index(i):
+                        raise ValueError(
+                            "Cannot bind UNSET_VALUE as a part of the routing key '%s'" % col_spec.name)
+                    # result[i] is already UNSET_VALUE from pre-allocation
                 else:
                     raise ValueError("Attempt to bind UNSET_VALUE while using unsuitable protocol version (%d < 4)" % proto_version)
             else:
@@ -652,18 +663,21 @@ class BoundStatement(Statement):
                     col_bytes = col_type.serialize(value, proto_version)
                     if uses_ce:
                         col_bytes = ce_policy.encrypt(col_desc, col_bytes)
-                    self.values.append(col_bytes)
+                    result[i] = col_bytes
                 except (TypeError, struct.error) as exc:
                     actual_type = type(value)
                     message = ('Received an argument of invalid type for column "%s". '
                                'Expected: %s, Got: %s; (%s)' % (col_spec.name, col_spec.type, actual_type, exc))
                     raise TypeError(message)
 
-        if proto_version >= 4:
-            diff = col_meta_len - len(self.values)
-            if diff:
-                for _ in range(diff):
-                    self._append_unset_value()
+        # Validate that trailing UNSET_VALUE padding doesn't cover routing key columns
+        if proto_version >= 4 and value_len < col_meta_len:
+            for i in range(value_len, col_meta_len):
+                if self.prepared_statement.is_routing_key_index(i):
+                    raise ValueError(
+                        "Cannot bind UNSET_VALUE as a part of the routing key '%s'" % col_meta[i].name)
+
+        self.values = result
 
         return self
 


### PR DESCRIPTION
## Summary

- Pre-allocate the `values` list in `BoundStatement.bind()` using `[UNSET_VALUE] * col_meta_len` (proto v4+) or `[None] * value_len` (proto v3) instead of starting with an empty list and calling `.append()` per value
- Eliminates the separate trailing UNSET_VALUE padding loop (`_append_unset_value()` called in a `for _ in range(diff)` loop)
- Uses index assignment (`result[i] = col_bytes`) instead of method lookup + call (`self.values.append(col_bytes)`)

## Motivation

Each `.append()` call involves a Python method lookup and function call, plus potential list resizing when capacity is exceeded. For prepared statements with many columns (common in LWT queries), this overhead is measurable. Pre-allocating with a known size and using index assignment avoids both the method dispatch overhead and all list resizing.

This is part of the LWT prepared statement performance improvement effort documented in scylladb/python-driver#751 (optimization B5).

## Changes

**`cassandra/query.py` - `BoundStatement.bind()`:**
- Initialize `result` list with known final size instead of `self.values = []`
- Replace `self.values.append(...)` with `result[i] = ...` using `enumerate(zip(...))`
- For proto v4+: `result = [UNSET_VALUE] * col_meta_len` — trailing unbound columns are already padded
- For proto v3: `result = [None] * value_len` — only provided values
- Inline the UNSET_VALUE routing key check (was previously delegated to `_append_unset_value()`)
- Assign `self.values = result` at the end (single attribute write)

## Testing

All existing tests pass:
- `tests/unit/test_parameter_binding.py` — 37/37 passed (V3, V4, V5 protocol versions)
- `tests/unit/test_query.py` — 6/6 passed
- `tests/unit/test_resultset.py` — 14/14 passed